### PR TITLE
Fix build container errors on some systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ COPY --chmod=700 ./solutions /root/
 RUN set -ex; \
     \
     apt-get update; \
-    apt-get install -y software-properties-common build-essential python2 python-pip file python3 language-pack-en gdb valgrind zsh git bash ruby wget curl tmux gcc vim make clang sudo gcc-multilib; \
-    add-apt-repository ppa:ubuntu-toolchain-r/test; \
+    apt-get install -y software-properties-common build-essential python2 python-pip file python3 language-pack-en gdb valgrind zsh git bash ruby wget curl tmux gcc vim make clang sudo gcc-multilib libseccomp-dev; \
     apt-get update; \
     useradd -m labs; \
     useradd -m admin; \

--- a/src/week2/challenges/bof-level6/Makefile
+++ b/src/week2/challenges/bof-level6/Makefile
@@ -1,4 +1,4 @@
-CC=gcc-4.7
+CC=gcc
 
 all: bof-level6
 

--- a/src/week2/challenges/bof-level8/Makefile
+++ b/src/week2/challenges/bof-level8/Makefile
@@ -1,4 +1,4 @@
-CC=gcc-4.7
+CC=gcc
 
 all: bof-level8
 


### PR DESCRIPTION
It looks like `gcc-4.7` was used in two Makefiles. I checked with another student who got the container running and I think they didn't have `gcc-4.7` installed in the container after it was built or in either Makefile. Is there a specific reason those challenges need 4.7? 

Perhaps there's a workaround which doesn't involve manually `wget`ing every `.deb` required for `4.7`---also the `ppa` for toolchains did not seem to work when I was trying to fix this issue.

`deprivileged.c` was missing `#include <seccomp.h>` so I added `libseccomp-dev`